### PR TITLE
Add branch alias dev-master => 1.0.x-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ extension/tests/*.log
 extension/tests/*.php
 
 support/libxhprof/.phutil_module_cache
+
+/composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
         ]
     },
     "bin": ["bin/xhprofile"],
+    "replace": {
+        "facebook/xhprof": "*",
+        "lox/xhprof": "*"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,10 @@
             "xhprof_lib/utils/xhprof_runs.php"
         ]
     },
-    "bin": ["bin/xhprofile"]
+    "bin": ["bin/xhprofile"],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "facebook/xhprof",
+    "name": "pbweb/xhprof",
     "type": "library",
     "description": "XHProf: A Hierarchical Profiler for PHP",
     "keywords": ["profiling", "performance"],


### PR DESCRIPTION
This introduces the `~1.0@dev` version (which points to the `master` branch) which can be used in `composer.json` when requiring this library.

This is to prevent the use of `dev-master` which is [considered bad practise](https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md).

Please also consider [adding tags](https://getcomposer.org/doc/02-libraries.md#specifying-the-version) to stable versions to make this library easier to manage when used in projects.
