### PR TITLE
work-around to avoid too long file names

### DIFF
--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -78,6 +78,15 @@ class XHProfRuns_Default implements iXHProfRuns {
 
     $file = "$run_id.$type." . $this->suffix;
 
+    // work-around to avoid too long file names
+    // inspired by https://github.com/simenbw
+    $maxLength = 255;
+    if (strlen($file) > $maxLength) {
+        $md5 = md5($file);
+        $suffixLength = strlen($this->suffix) + 1;
+        $file = substr_replace($file, $md5, $maxLength - (strlen($md5) + $suffixLength), -$suffixLength);
+    }
+
     if (!empty($this->dir)) {
       $file = $this->dir . "/" . $file;
     }


### PR DESCRIPTION
This workaround will avoid too long filenames when saving to temp folder (less than 256 characters), originally fixed friom simenbw at https://github.com/simenbw/xhprof/commits/master
